### PR TITLE
Change logical operator

### DIFF
--- a/src/read_MSH_Mesh.cpp
+++ b/src/read_MSH_Mesh.cpp
@@ -358,12 +358,12 @@ int32_t Mesh::read_msh_file (const char* const filename) {
 				// now, do the nodes appear in the correct order?
 				// HACK - ASSUMES THIS IS A QUAD
 				for (size_t k = 0; k < 4; ++k) {
-					if (elements[j].nodes[k] == n0 and
+					if (elements[j].nodes[k] == n0 &&
 					    elements[j].nodes[(k+1)%4] == n1) {
 						correctorder = true;
 					}
 				}
-				if (not correctorder) {
+				if (!correctorder) {
 					std::cout << "      flipping edge " << i << std::endl;
 					//std::cout << "    original order ";
 					//for (size_t k=0; k<edges[i].nodes.size(); ++k) std::cout << " " << edges[i].nodes[k];


### PR DESCRIPTION
I am not sure if some compiler understands `and` and `not` keywords, or maybe a configuration file with its definition is missing. But MSVC only compiles with C++ "default" logical operators.